### PR TITLE
Release v0.2.2: Fix content centering in focus mode

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-focus-mode-plugin",
   "name": "Focus mode plugin",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "minAppVersion": "0.12.0",
   "description": "Hide sidebars, tabs, and other UI elements for distraction-free writing without fullscreen mode",
   "author": "Razum",

--- a/styles.css
+++ b/styles.css
@@ -95,3 +95,16 @@
 .focus-mode .markdown-preview-view {
   padding: 20px;
 }
+
+/* Center the active pane when in focus mode */
+.focus-mode .workspace-split.mod-root {
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
+
+.focus-mode .workspace-split.mod-root > .workspace-leaf:not([style*="display: none"]) {
+  width: 100%;
+  max-width: none;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- Fixed bug where content remained side-aligned instead of centering when focusing on one pane with multiple panes open
- Updated version to 0.2.2 in manifest.json
- Added CSS rules to center the active pane properly

## Test plan
- [x] Build the plugin successfully
- [x] Test content centering behavior in focus mode
- [x] Verify version bump in manifest.json

🤖 Generated with [Claude Code](https://claude.ai/code)